### PR TITLE
wasip1: use existing network address values

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  GOPRIVATE: github.com/stealthrocket
-  GH_ACCESS_TOKEN: ${{ secrets.PRIVATE_ACCESS_TOKEN }}
-
 jobs:
   test:
     name: Go Test
@@ -37,5 +33,4 @@ jobs:
         ls -lah gotip.tar.gz
         mkdir -p $HOME/gotip
         tar -C $HOME/gotip -xzf gotip.tar.gz
-    - run: git config --global url.https://$GH_ACCESS_TOKEN@github.com.insteadOf https://github.com
     - run: make test GO=$HOME/gotip/bin/go GOPATH=$HOME/gotip

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: proto test lint wasirun
+.PHONY: clean proto test lint wasirun
 
 GO ?= go
 GOPATH ?= $(shell $(GO) env GOPATH)
@@ -21,6 +21,9 @@ grpc.pb.go = $(grpc.proto:.proto=_grpc.pb.go)
 # go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@latest
 ttrpc.proto = $(wildcard ttrpc/*.proto)
 ttrpc.pb.go = $(ttrpc.proto:.proto=_ttrpc.pb.go)
+
+clean:
+	rm -f *.test
 
 proto: $(grpc.pb.go) $(ttrpc.pb.go)
 

--- a/mysql/mysql_wasip1.go
+++ b/mysql/mysql_wasip1.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	networks := []string{"tcp", "tcp4", "tcp6", "unix"}
+	networks := []string{"tcp", "tcp4", "tcp6"}
 	for i := range networks {
 		network := networks[i]
 		mysql.RegisterDialContext(network, func(ctx context.Context, address string) (net.Conn, error) {

--- a/wasip1/listen_wasip1.go
+++ b/wasip1/listen_wasip1.go
@@ -72,28 +72,16 @@ func listenAddr(addr net.Addr) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	switch l.(type) {
-	case *net.UnixListener:
-		addr = sockaddrToUnixAddr(sockaddr)
-	case *net.TCPListener:
-		addr = sockaddrToTCPAddr(sockaddr)
-	}
-	return &listener{l, addr}, nil
+	setNetAddr(l.Addr(), sockaddr)
+	return listener{l}, nil
 }
 
-type listener struct {
-	net.Listener
-	addr net.Addr
-}
+type listener struct{ net.Listener }
 
-func (l *listener) Accept() (net.Conn, error) {
+func (l listener) Accept() (net.Conn, error) {
 	c, err := l.Listener.Accept()
 	if err != nil {
 		return nil, err
 	}
 	return makeConn(c)
-}
-
-func (l *listener) Addr() net.Addr {
-	return l.addr
 }

--- a/wasip1/listen_wasip1.go
+++ b/wasip1/listen_wasip1.go
@@ -73,12 +73,12 @@ func listenAddr(addr net.Addr) (net.Listener, error) {
 		return nil, err
 	}
 	setNetAddr(l.Addr(), sockaddr)
-	return listener{l}, nil
+	return &listener{l}, nil
 }
 
 type listener struct{ net.Listener }
 
-func (l listener) Accept() (net.Conn, error) {
+func (l *listener) Accept() (net.Conn, error) {
 	c, err := l.Listener.Accept()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR depends on https://go-review.googlesource.com/c/go/+/502375/1

With this change, we remove the `wasip1.conn` wrapper for `net.Conn` and instead operate on the `net.Addr` values returned by the network connections. This mechanism relies on documented behavior of the `net` package which says that the connection objects do not modify their address values and return the same value over multiple calls to their `LocalAddr` and `RemoteAddr` methods.
