### PR TITLE
wasip1: change lookupAddr to correctly handle numeric IP addresses

### DIFF
--- a/wasip1/lookup_wasip1.go
+++ b/wasip1/lookup_wasip1.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"strconv"
 )
 
 func dialResolverNotSupported(ctx context.Context, network, address string) (net.Conn, error) {
@@ -54,6 +55,9 @@ func lookupAddr(op, network, address string) (net.Addr, error) {
 	}
 	if ip := net.ParseIP(hostname); ip != nil {
 		hints.flags |= AI_NUMERICHOST
+	}
+	if _, err = strconv.Atoi(service); err == nil {
+		hints.flags |= AI_NUMERICSERV
 	}
 	if op == "listen" && hostname == "" {
 		hints.flags |= AI_PASSIVE

--- a/wasip1/lookup_wasip1.go
+++ b/wasip1/lookup_wasip1.go
@@ -52,6 +52,9 @@ func lookupAddr(op, network, address string) (net.Addr, error) {
 	if err != nil {
 		return nil, net.InvalidAddrError(address)
 	}
+	if ip := net.ParseIP(hostname); ip != nil {
+		hints.flags |= AI_NUMERICHOST
+	}
 	if op == "listen" && hostname == "" {
 		hints.flags |= AI_PASSIVE
 	}

--- a/wasip1/syscall_wasmedge_wasip1.go
+++ b/wasip1/syscall_wasmedge_wasip1.go
@@ -378,8 +378,8 @@ func getaddrinfo(name, service string, hints *addrInfo, results []addrInfo) (int
 			r.address = &r.inet4addr
 		case AF_INET6:
 			r.inet6addr.port = int(port)
+			copy(r.inet6addr.addr[:], results[i].sockData[2:])
 			r.address = &r.inet6addr
-			copy(r.inet4addr.addr[:], results[i].sockData[2:])
 		default:
 			r.address = nil
 		}


### PR DESCRIPTION
This PR makes 3 changes:

1. Adds `hints.flags |= AI_NUMERICHOST` if `lookupAddr` is called with an IP address. This allows `wasip1.DialContext()` to accept and resolve an IP address.
2. Adds `hints.flags |= AI_NUMERICSERV` if `lookupAddr` is called with a port number. This optimizes handling of numeric service / port numbers.
3. Fixes IPv6 handling in `getaddrinfo`. This allows `getaddrinfo` to correctly return an IPv6 address.



Would it make sense to export `lookupAddr` or add a `Resolver` type to the `wasip1` package that can resolve addresses? Given that the underlying syscall is blocking, I’d like to be able to cache DNS lookups and bypass the syscall when opening sockets.