### PR TITLE
fix wasmedge getaddrinfo + test address lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ GO ?= gotip
 GOPATH ?= $(shell $(GO) env GOPATH)
 wasirun = $(GOPATH)/bin/wasirun
 
-packages.dir = $(wildcard */)
+packages.dir = $(filter-out testdata/,$(wildcard */))
 packages.test = $(packages.dir:/=.test)
 test: proto wasirun $(packages.test)
 	@for pkg in $(packages.test); do \
 		tmp=$$(mktemp); \
-		$(wasirun) --dir=/ $$pkg > $$tmp; \
+		$(wasirun) --dir=/ --dns-server=127.0.0.1:5453 $$pkg > $$tmp; \
 		if (($$?)); then cat $$tmp; exit 1; else printf "ok\tgithub.com/stealthrocket/net/$$pkg\n"; fi \
 	done
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,13 @@ services:
       POSTGRES_PASSWORD: password
     ports:
     - '5432:5432'
+
+  coredns:
+    image: coredns/coredns:1.10.1
+    command:
+    - '-conf=/etc/coredns/Corefile'
+    ports:
+    - '5453:53/tcp'
+    - '5453:53/udp'
+    volumes:
+    - ./testdata/etc/coredns:/etc/coredns

--- a/testdata/etc/coredns/Corefile
+++ b/testdata/etc/coredns/Corefile
@@ -1,0 +1,9 @@
+. {
+  log
+  errors
+  hosts {
+        10.0.0.1 example.com
+        10.0.0.2 example.com
+        fe80::ec34:70ff:fe53:470e example.com
+  }
+}

--- a/testdata/etc/coredns/Corefile
+++ b/testdata/etc/coredns/Corefile
@@ -2,8 +2,8 @@
   log
   errors
   hosts {
+        fe80::ec34:70ff:fe53:470e example.com
         10.0.0.1 example.com
         10.0.0.2 example.com
-        fe80::ec34:70ff:fe53:470e example.com
   }
 }

--- a/wasip1/listen_wasip1.go
+++ b/wasip1/listen_wasip1.go
@@ -3,6 +3,7 @@
 package wasip1
 
 import (
+	"context"
 	"net"
 	"os"
 	"syscall"
@@ -10,14 +11,14 @@ import (
 
 // Listen announces on the local network address.
 func Listen(network, address string) (net.Listener, error) {
-	addr, err := lookupAddr("listen", network, address)
+	addrs, err := lookupAddr(context.Background(), "listen", network, address)
 	if err != nil {
 		addr := &netAddr{network, address}
 		return nil, listenErr(addr, err)
 	}
-	lstn, err := listenAddr(addr)
+	lstn, err := listenAddr(addrs[0])
 	if err != nil {
-		return nil, listenErr(addr, err)
+		return nil, listenErr(addrs[0], err)
 	}
 	return lstn, nil
 }

--- a/wasip1/lookup_wasip1_test.go
+++ b/wasip1/lookup_wasip1_test.go
@@ -1,0 +1,200 @@
+//go:build wasip1
+
+package wasip1
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestLookupAddr(t *testing.T) {
+	tests := []struct {
+		op      string
+		network string
+		address string
+		addrs   []net.Addr
+		err     error
+	}{
+		{
+			op:      "dial",
+			network: "tcp",
+			address: "example.com:443",
+			addrs: []net.Addr{
+				&net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 443},
+				&net.TCPAddr{IP: net.IPv4(10, 0, 0, 2), Port: 443},
+				&net.TCPAddr{IP: net.ParseIP("fe80::ec34:70ff:fe53:470e"), Port: 443},
+			},
+		},
+
+		{
+			op:      "dial",
+			network: "tcp4",
+			address: "example.com:443",
+			addrs: []net.Addr{
+				&net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 443},
+				&net.TCPAddr{IP: net.IPv4(10, 0, 0, 2), Port: 443},
+			},
+		},
+
+		{
+			op:      "dial",
+			network: "tcp6",
+			address: "example.com:443",
+			addrs: []net.Addr{
+				&net.TCPAddr{IP: net.ParseIP("fe80::ec34:70ff:fe53:470e"), Port: 443},
+			},
+		},
+
+		{
+			op:      "dial",
+			network: "udp",
+			address: "example.com:80",
+			addrs: []net.Addr{
+				&net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 80},
+				&net.UDPAddr{IP: net.IPv4(10, 0, 0, 2), Port: 80},
+				&net.UDPAddr{IP: net.ParseIP("fe80::ec34:70ff:fe53:470e"), Port: 80},
+			},
+		},
+
+		{
+			op:      "dial",
+			network: "udp4",
+			address: "example.com:80",
+			addrs: []net.Addr{
+				&net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 80},
+				&net.UDPAddr{IP: net.IPv4(10, 0, 0, 2), Port: 80},
+			},
+		},
+
+		{
+			op:      "dial",
+			network: "udp6",
+			address: "example.com:80",
+			addrs: []net.Addr{
+				&net.UDPAddr{IP: net.ParseIP("fe80::ec34:70ff:fe53:470e"), Port: 80},
+			},
+		},
+
+		{
+			op:      "dial",
+			network: "unix",
+			address: "example.sock",
+			addrs: []net.Addr{
+				&net.UnixAddr{Net: "unix", Name: "example.sock"},
+			},
+		},
+
+		{
+			op:      "listen",
+			network: "tcp",
+			address: ":443",
+			addrs: []net.Addr{
+				&net.TCPAddr{IP: net.IPv4(0, 0, 0, 0), Port: 443},
+			},
+		},
+
+		{
+			op:      "listen",
+			network: "tcp4",
+			address: ":443",
+			addrs: []net.Addr{
+				&net.TCPAddr{IP: net.IPv4(0, 0, 0, 0), Port: 443},
+			},
+		},
+
+		{
+			op:      "listen",
+			network: "tcp6",
+			address: ":443",
+			addrs: []net.Addr{
+				&net.TCPAddr{IP: net.ParseIP("::"), Port: 443},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.op+" "+test.network+" "+test.address, func(t *testing.T) {
+			addrs, err := lookupAddr(context.Background(), test.op, test.network, test.address)
+			if !errors.Is(err, test.err) {
+				t.Errorf("errors mismatch:\nwant = %v\ngot  = %v", test.err, err)
+			}
+			assertEqualAllAddrs(t, addrs, test.addrs)
+		})
+	}
+}
+
+func assertEqualAllAddrs(t *testing.T, addrs1, addrs2 []net.Addr) {
+	if len(addrs1) != len(addrs2) {
+		t.Errorf("number of addresses mismatch: %d != %d", len(addrs1), len(addrs2))
+	} else {
+		for i := range addrs1 {
+			assertEqualAddr(t, addrs1[i], addrs2[i])
+		}
+	}
+}
+
+func assertEqualAddr(t *testing.T, addr1, addr2 net.Addr) {
+	switch a1 := addr1.(type) {
+	case *net.TCPAddr:
+		if a2, ok := addr2.(*net.TCPAddr); ok {
+			assertEqualTCPAddr(t, a1, a2)
+			return
+		}
+	case *net.UDPAddr:
+		if a2, ok := addr2.(*net.UDPAddr); ok {
+			assertEqualUDPAddr(t, a1, a2)
+			return
+		}
+	case *net.UnixAddr:
+		if a2, ok := addr2.(*net.UnixAddr); ok {
+			assertEqualUnixAddr(t, a1, a2)
+			return
+		}
+	}
+	t.Errorf("cannot compare addresses of type %T and %T", addr1, addr2)
+}
+
+func assertEqualTCPAddr(t *testing.T, addr1, addr2 *net.TCPAddr) {
+	assertEqualIPAndPort(t,
+		addr1.IP,
+		addr2.IP,
+		addr1.Port,
+		addr2.Port,
+		addr1.Zone,
+		addr2.Zone,
+	)
+}
+
+func assertEqualUDPAddr(t *testing.T, addr1, addr2 *net.UDPAddr) {
+	assertEqualIPAndPort(t,
+		addr1.IP,
+		addr2.IP,
+		addr1.Port,
+		addr2.Port,
+		addr1.Zone,
+		addr2.Zone,
+	)
+}
+
+func assertEqualUnixAddr(t *testing.T, addr1, addr2 *net.UnixAddr) {
+	if addr1.Net != addr2.Net {
+		t.Errorf("networks mismatch: %q != %q", addr1.Net, addr2.Net)
+	}
+	if addr1.Name != addr2.Name {
+		t.Errorf("unix socket names mismatch: %q != %q", addr1.Name, addr2.Name)
+	}
+}
+
+func assertEqualIPAndPort(t *testing.T, ip1, ip2 net.IP, port1, port2 int, zone1, zone2 string) {
+	if !ip1.Equal(ip2) {
+		t.Errorf("ip addreses mismatch: %v != %v", ip1, ip2)
+	}
+	if port1 != port2 {
+		t.Errorf("ports mismatch: %d != %d", port1, port2)
+	}
+	if zone1 != zone2 {
+		t.Errorf("zones mismatch: %q != %q", zone1, zone2)
+	}
+}

--- a/wasip1/syscall_wasmedge_wasip1.go
+++ b/wasip1/syscall_wasmedge_wasip1.go
@@ -344,7 +344,7 @@ func getaddrinfo(name, service string, hints *addrInfo, results []addrInfo) (int
 			ai_canonnamelen: uint32(unsafe.Sizeof(addrInfo{}.cannoname)),
 		}
 		if i > 0 {
-			results[i-1].sockAddrInfo.ai_next = uintptr32(uintptr(unsafe.Pointer(&results[i-1].sockAddrInfo)))
+			results[i-1].sockAddrInfo.ai_next = uintptr32(uintptr(unsafe.Pointer(&results[i].sockAddrInfo)))
 		}
 	}
 


### PR DESCRIPTION
This PR addresses a bug that was causing `getaddrinfo` to return only the last address of the results.