### PR TITLE
unix: implement Dial and Listen for unix domain sockets

### DIFF
--- a/wasip1/lookup_wasip1.go
+++ b/wasip1/lookup_wasip1.go
@@ -80,10 +80,10 @@ func lookupAddr(ctx context.Context, op, network, address string) ([]net.Addr, e
 		switch a := r.address.(type) {
 		case *sockaddrInet4:
 			ip = a.addr[:]
-			port = a.port
+			port = int(a.port)
 		case *sockaddrInet6:
 			ip = a.addr[:]
-			port = a.port
+			port = int(a.port)
 		}
 		switch network {
 		case "tcp", "tcp4", "tcp6":

--- a/wasip1/syscall_wasmedge_wasip1.go
+++ b/wasip1/syscall_wasmedge_wasip1.go
@@ -57,8 +57,8 @@ type sockaddr interface {
 }
 
 type sockaddrInet4 struct {
-	port int
 	addr [4]byte
+	port uint32
 	raw  addressBuffer
 }
 
@@ -69,13 +69,13 @@ func (s *sockaddrInet4) sockaddr() (unsafe.Pointer, error) {
 }
 
 func (s *sockaddrInet4) sockport() int {
-	return s.port
+	return int(s.port)
 }
 
 type sockaddrInet6 struct {
-	port int
-	zone uint32
 	addr [16]byte
+	port uint32
+	zone uint32
 	raw  addressBuffer
 }
 
@@ -89,7 +89,7 @@ func (s *sockaddrInet6) sockaddr() (unsafe.Pointer, error) {
 }
 
 func (s *sockaddrInet6) sockport() int {
-	return s.port
+	return int(s.port)
 }
 
 type sockaddrUnix struct {
@@ -244,7 +244,7 @@ func getsockname(fd int) (sa sockaddr, err error) {
 	if errno != 0 {
 		return nil, errno
 	}
-	return anyToSockaddr(&rsa, int(port))
+	return anyToSockaddr(&rsa, port)
 }
 
 func getpeername(fd int) (sockaddr, error) {
@@ -258,10 +258,10 @@ func getpeername(fd int) (sockaddr, error) {
 	if errno != 0 {
 		return nil, errno
 	}
-	return anyToSockaddr(&rsa, int(port))
+	return anyToSockaddr(&rsa, port)
 }
 
-func anyToSockaddr(rsa *rawSockaddrAny, port int) (sockaddr, error) {
+func anyToSockaddr(rsa *rawSockaddrAny, port uint32) (sockaddr, error) {
 	switch rsa.family {
 	case AF_INET:
 		addr := sockaddrInet4{port: port}
@@ -373,11 +373,11 @@ func getaddrinfo(name, service string, hints *addrInfo, results []addrInfo) (int
 		port := binary.BigEndian.Uint16(results[i].sockData[:2])
 		switch results[i].sockAddr.sa_family {
 		case AF_INET:
-			r.inet4addr.port = int(port)
+			r.inet4addr.port = uint32(port)
 			copy(r.inet4addr.addr[:], results[i].sockData[2:])
 			r.address = &r.inet4addr
 		case AF_INET6:
-			r.inet6addr.port = int(port)
+			r.inet6addr.port = uint32(port)
 			copy(r.inet6addr.addr[:], results[i].sockData[2:])
 			r.address = &r.inet6addr
 		default:

--- a/wasip1/unix_wasip1.go
+++ b/wasip1/unix_wasip1.go
@@ -1,0 +1,74 @@
+//go:build wasip1
+
+package wasip1
+
+// Unix sockets are not yet supported for GOOS=wasip1 because there is no
+// mechanism to create a *net.UnixConn or *net.UnixListener from an *os.File
+// due to WASI preview 1 not having the concept of unix sockets and only
+// having file types for datagram and stream sockets, which are mapped to
+// UDP and TCP sockets by the net package.
+//
+// We emulate unix sockets to provide minimum support when calling Dial with
+// a "unix" network. The downside is that connections returned by the wasip1
+// dial functions are not actually of type *net.UnixConn, applications that
+// used type assertions to dynamically discover the connection type will not
+// be compatible with this approach. The same limitation applies to listeners.
+
+import (
+	"net"
+	"syscall"
+)
+
+type unixConn struct {
+	net.Conn
+	laddr net.UnixAddr
+	raddr net.UnixAddr
+}
+
+func (c *unixConn) LocalAddr() net.Addr {
+	return &c.laddr
+}
+
+func (c *unixConn) RemoteAddr() net.Addr {
+	return &c.raddr
+}
+
+func (c *unixConn) CloseRead() error {
+	if cr, ok := c.Conn.(closeReader); ok {
+		return cr.CloseRead()
+	}
+	return &net.OpError{
+		Op:     "close",
+		Net:    "unix",
+		Source: c.LocalAddr(),
+		Err:    syscall.ENOTSUP,
+	}
+}
+
+func (c *unixConn) CloseWrite() error {
+	if cw, ok := c.Conn.(closeWriter); ok {
+		return cw.CloseWrite()
+	}
+	return &net.OpError{
+		Op:     "close",
+		Net:    "unix",
+		Source: c.LocalAddr(),
+		Err:    syscall.ENOTSUP,
+	}
+}
+
+type closeReader interface {
+	CloseRead() error
+}
+
+type closeWriter interface {
+	CloseWrite() error
+}
+
+var (
+	_ closeReader = (*net.UnixConn)(nil)
+	_ closeWriter = (*net.UnixConn)(nil)
+
+	_ closeReader = (*unixConn)(nil)
+	_ closeWriter = (*unixConn)(nil)
+)


### PR DESCRIPTION
This PR fixes support for unix sockets; our previous implementation was broken by recent changes from https://go-review.googlesource.com/c/go/+/502316/5