### PR TITLE
wasip1: add wasip1.ListenPacket and implementation of net.PacketConn

### DIFF
--- a/wasip1/dial_wasip1.go
+++ b/wasip1/dial_wasip1.go
@@ -4,6 +4,7 @@ package wasip1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -128,18 +129,18 @@ func dialAddr(ctx context.Context, addr net.Addr) (net.Conn, error) {
 	if err := setNonBlock(fd); err != nil {
 		return nil, err
 	}
-	// if sotype == SOCK_DGRAM && proto != AF_UNIX {
-	// 	if err := setsockopt(fd, SOL_SOCKET, SO_BROADCAST, 1); err != nil {
-	// 		// If the system does not support broadcast we should still be able
-	// 		// to use the datagram socket.
-	// 		switch {
-	// 		case errors.Is(err, syscall.EINVAL):
-	// 		case errors.Is(err, syscall.ENOPROTOOPT):
-	// 		default:
-	// 			return nil, os.NewSyscallError("setsockopt", err)
-	// 		}
-	// 	}
-	// }
+	if sotype == SOCK_DGRAM && proto != AF_UNIX {
+		if err := setsockopt(fd, SOL_SOCKET, SO_BROADCAST, 1); err != nil {
+			// If the system does not support broadcast we should still be able
+			// to use the datagram socket.
+			switch {
+			case errors.Is(err, syscall.EINVAL):
+			case errors.Is(err, syscall.ENOPROTOOPT):
+			default:
+				return nil, os.NewSyscallError("setsockopt", err)
+			}
+		}
+	}
 
 	connectAddr, err := socketAddress(addr)
 	if err != nil {

--- a/wasip1/listen_wasip1.go
+++ b/wasip1/listen_wasip1.go
@@ -4,14 +4,22 @@ package wasip1
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"io"
 	"net"
+	"net/netip"
 	"os"
 	"syscall"
+	"time"
 )
 
 // Listen announces on the local network address.
 func Listen(network, address string) (net.Listener, error) {
+	switch network {
+	case "tcp", "tcp4", "tcp6", "unix":
+	default:
+		return nil, unsupportedNetwork(network, address)
+	}
 	addrs, err := lookupAddr(context.Background(), "listen", network, address)
 	if err != nil {
 		addr := &netAddr{network, address}
@@ -24,35 +32,49 @@ func Listen(network, address string) (net.Listener, error) {
 	return lstn, nil
 }
 
+// ListenPacket creates a listening packet connection.
+func ListenPacket(network, address string) (net.PacketConn, error) {
+	switch network {
+	case "udp", "udp4", "udp6", "unixgram":
+	default:
+		return nil, unsupportedNetwork(network, address)
+	}
+	addrs, err := lookupAddr(context.Background(), "listen", network, address)
+	if err != nil {
+		addr := &netAddr{network, address}
+		return nil, listenErr(addr, err)
+	}
+	conn, err := listenPacketAddr(addrs[0])
+	if err != nil {
+		return nil, listenErr(addrs[0], err)
+	}
+	return conn, nil
+}
+
+func unsupportedNetwork(network, address string) error {
+	return fmt.Errorf("unsupported network: %s://%s", network, address)
+}
+
 func listenErr(addr net.Addr, err error) error {
 	return newOpError("listen", addr, err)
 }
 
 func listenAddr(addr net.Addr) (net.Listener, error) {
-	sotype, err := socketType(addr)
+	fd, err := socket(family(addr), SOCK_STREAM, 0)
 	if err != nil {
 		return nil, os.NewSyscallError("socket", err)
 	}
-	fd, err := socket(family(addr), sotype, 0)
-	if err != nil {
-		return nil, os.NewSyscallError("socket", err)
-	}
-
-	if err := syscall.SetNonblock(fd, true); err != nil {
-		syscall.Close(fd)
-		return nil, os.NewSyscallError("setnonblock", err)
-	}
-	if err := setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, 1); err != nil {
-		// The runtime may not support the option; if that's the case and the
-		// address is already in use, binding the socket will fail and we will
-		// report the error then.
-		switch {
-		case errors.Is(err, syscall.ENOPROTOOPT):
-		case errors.Is(err, syscall.EINVAL):
-		default:
+	defer func() {
+		if fd >= 0 {
 			syscall.Close(fd)
-			return nil, os.NewSyscallError("setsockopt", err)
 		}
+	}()
+
+	if err := setNonBlock(fd); err != nil {
+		return nil, err
+	}
+	if err := setReuseAddress(fd); err != nil {
+		return nil, err
 	}
 
 	bindAddr, err := socketAddress(addr)
@@ -60,29 +82,63 @@ func listenAddr(addr net.Addr) (net.Listener, error) {
 		return nil, os.NewSyscallError("bind", err)
 	}
 	if err := bind(fd, bindAddr); err != nil {
-		syscall.Close(fd)
 		return nil, os.NewSyscallError("bind", err)
 	}
 	const backlog = 64 // TODO: configurable?
 	if err := listen(fd, backlog); err != nil {
-		syscall.Close(fd)
 		return nil, os.NewSyscallError("listen", err)
 	}
 
-	sockaddr, err := getsockname(fd)
+	name, err := getsockname(fd)
 	if err != nil {
-		syscall.Close(fd)
 		return nil, os.NewSyscallError("getsockname", err)
 	}
 
 	f := os.NewFile(uintptr(fd), "")
+	fd = -1 // now the *os.File owns the file descriptor
 	defer f.Close()
 
 	l, err := net.FileListener(f)
 	if err != nil {
 		return nil, err
 	}
-	return makeListener(l, sockaddr), nil
+	return makeListener(l, name), nil
+}
+
+func listenPacketAddr(addr net.Addr) (net.PacketConn, error) {
+	fd, err := socket(family(addr), SOCK_DGRAM, 0)
+	if err != nil {
+		return nil, os.NewSyscallError("socket", err)
+	}
+	defer func() {
+		if fd >= 0 {
+			syscall.Close(fd)
+		}
+	}()
+
+	if err := setNonBlock(fd); err != nil {
+		return nil, err
+	}
+	if err := setReuseAddress(fd); err != nil {
+		return nil, err
+	}
+
+	bindAddr, err := socketAddress(addr)
+	if err != nil {
+		return nil, os.NewSyscallError("bind", err)
+	}
+	if err := bind(fd, bindAddr); err != nil {
+		return nil, os.NewSyscallError("bind", err)
+	}
+
+	name, err := getsockname(fd)
+	if err != nil {
+		return nil, os.NewSyscallError("getsockname", err)
+	}
+
+	f := os.NewFile(uintptr(fd), "")
+	fd = -1 // now the *os.File owns the file descriptor
+	return makePacketConn(f, name, nil), nil
 }
 
 type listener struct{ net.Listener }
@@ -111,6 +167,223 @@ func makeListener(l net.Listener, addr sockaddr) net.Listener {
 	default:
 		l = &listener{l}
 	}
-	setNetAddr(l.Addr(), addr)
+	setNetAddr(SOCK_STREAM, l.Addr(), addr)
 	return l
+}
+
+func makePacketConn(f *os.File, laddr, raddr sockaddr) *packetConn {
+	conn := &packetConn{file: f}
+	if _, unix := laddr.(*sockaddrUnix); unix {
+		conn.laddr = new(net.UnixAddr)
+		conn.raddr = new(net.UnixAddr)
+	} else {
+		conn.laddr = new(net.UDPAddr)
+		conn.raddr = new(net.UDPAddr)
+	}
+	setNetAddr(SOCK_DGRAM, conn.laddr, laddr)
+	setNetAddr(SOCK_DGRAM, conn.raddr, raddr)
+	conn.conn, _ = f.SyscallConn()
+	return conn
+}
+
+type packetConn struct {
+	file  *os.File
+	laddr net.Addr
+	raddr net.Addr
+	conn  syscall.RawConn
+}
+
+func (c *packetConn) Close() error {
+	return c.file.Close()
+}
+
+func (c *packetConn) CloseRead() (err error) {
+	rawConnErr := c.conn.Control(func(fd uintptr) {
+		err = shutdown(int(fd), 1)
+	})
+	if rawConnErr != nil {
+		err = rawConnErr
+	}
+	return
+}
+
+func (c *packetConn) CloseWrite() (err error) {
+	rawConnErr := c.conn.Control(func(fd uintptr) {
+		err = shutdown(int(fd), 2)
+	})
+	if rawConnErr != nil {
+		err = rawConnErr
+	}
+	return
+}
+
+func (c *packetConn) Read(b []byte) (int, error) {
+	n, _, _, _, err := c.ReadMsgUDPAddrPort(b, nil)
+	return n, err
+}
+
+func (c *packetConn) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
+	switch c.laddr.(type) {
+	case *net.UDPAddr:
+		n, _, _, addr, err = c.ReadMsgUDP(b, nil)
+	default:
+		n, _, _, addr, err = c.ReadMsgUnix(b, nil)
+	}
+	return
+}
+
+func (c *packetConn) ReadMsgUnix(b, oob []byte) (n, oobn, flags int, addr *net.UnixAddr, err error) {
+	rawConnErr := c.conn.Read(func(fd uintptr) (done bool) {
+		var raw rawSockaddrAny
+		var oflags int32
+		n, raw, _, oflags, err = recvfrom(int(fd), [][]byte{b}, 0)
+		if err == syscall.EAGAIN {
+			return false
+		}
+		if err == syscall.EINVAL {
+			// This error occurs when the socket is shutdown asynchronusly
+			// by a call to CloseRead.
+			n, err = 0, io.EOF
+		} else {
+			addr = &net.UnixAddr{
+				Net:  "unixgram",
+				Name: string(raw.addr[:strlen(raw.addr[:])]),
+			}
+		}
+		flags = int(oflags)
+		return true
+	})
+	if rawConnErr != nil {
+		err = rawConnErr
+	}
+	if n == 0 && err == nil {
+		err = io.EOF
+	}
+	return
+}
+
+func (c *packetConn) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error) {
+	n, oobn, flags, addrPort, err := c.ReadMsgUDPAddrPort(b, oob)
+	return n, oobn, flags, net.UDPAddrFromAddrPort(addrPort), err
+}
+
+func (c *packetConn) ReadMsgUDPAddrPort(b, oob []byte) (n, oobn, flags int, addrPort netip.AddrPort, err error) {
+	rawConnErr := c.conn.Read(func(fd uintptr) (done bool) {
+		var raw rawSockaddrAny
+		var port int32
+		var oflags int32
+		n, raw, port, oflags, err = recvfrom(int(fd), [][]byte{b}, 0)
+		if err == syscall.EAGAIN {
+			return false
+		}
+		if err == syscall.EINVAL {
+			// This error occurs when the socket is shutdown asynchronusly
+			// by a call to CloseRead.
+			n, err = 0, io.EOF
+			return true
+		}
+		var addr netip.Addr
+		switch raw.family {
+		case AF_INET:
+			addr = netip.AddrFrom4(([4]byte)(raw.addr[:4]))
+		case AF_INET6:
+			addr = netip.AddrFrom16(([16]byte)(raw.addr[:16]))
+		}
+		addrPort = netip.AddrPortFrom(addr, uint16(port))
+		flags = int(oflags)
+		return true
+	})
+	if rawConnErr != nil {
+		err = rawConnErr
+	}
+	if n == 0 && err == nil {
+		err = io.EOF
+	}
+	return
+}
+
+func (c *packetConn) Write(b []byte) (int, error) {
+	return c.file.Write(b)
+}
+
+func (c *packetConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+	switch a := addr.(type) {
+	case *net.UDPAddr:
+		if _, ok := c.laddr.(*net.UDPAddr); ok {
+			n, _, err := c.WriteMsgUDP(b, nil, a)
+			return n, err
+		}
+	case *net.UnixAddr:
+		if _, ok := c.laddr.(*net.UnixAddr); ok {
+			n, _, err := c.WriteMsgUnix(b, nil, a)
+			return n, err
+		}
+	}
+	return 0, &net.OpError{
+		Op:     "write",
+		Net:    c.laddr.Network(),
+		Addr:   c.laddr,
+		Source: addr,
+		Err:    net.InvalidAddrError("address type mismatch"),
+	}
+}
+
+func (c *packetConn) WriteMsgUnix(b, oob []byte, addr *net.UnixAddr) (n, oobn int, err error) {
+	rawConnErr := c.conn.Write(func(fd uintptr) (done bool) {
+		raw := rawSockaddrAny{family: AF_UNIX}
+		copy(raw.addr[:], addr.Name)
+		n, err = sendto(int(fd), [][]byte{b}, raw, 0, 0)
+		return err != syscall.EAGAIN
+	})
+	if rawConnErr != nil {
+		err = rawConnErr
+	}
+	return
+}
+
+func (c *packetConn) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
+	return c.WriteMsgUDPAddrPort(b, oob, addr.AddrPort())
+}
+
+func (c *packetConn) WriteMsgUDPAddrPort(b, oob []byte, addrPort netip.AddrPort) (n, oobn int, err error) {
+	rawConnErr := c.conn.Write(func(fd uintptr) (done bool) {
+		var raw rawSockaddrAny
+		addr := addrPort.Addr()
+		port := addrPort.Port()
+		if addr.Is4() {
+			raw.family = AF_INET
+			ipv4 := addr.As4()
+			copy(raw.addr[:], ipv4[:])
+		} else {
+			raw.family = AF_INET6
+			ipv6 := addr.As16()
+			copy(raw.addr[:], ipv6[:])
+		}
+		n, err = sendto(int(fd), [][]byte{b}, raw, int32(port), 0)
+		return err != syscall.EAGAIN
+	})
+	if rawConnErr != nil {
+		err = rawConnErr
+	}
+	return
+}
+
+func (c *packetConn) LocalAddr() net.Addr {
+	return c.laddr
+}
+
+func (c *packetConn) RemoteAddr() net.Addr {
+	return c.raddr
+}
+
+func (c *packetConn) SetDeadline(t time.Time) error {
+	return c.file.SetDeadline(t)
+}
+
+func (c *packetConn) SetReadDeadline(t time.Time) error {
+	return c.file.SetReadDeadline(t)
+}
+
+func (c *packetConn) SetWriteDeadline(t time.Time) error {
+	return c.file.SetWriteDeadline(t)
 }

--- a/wasip1/net_wasip1_test.go
+++ b/wasip1/net_wasip1_test.go
@@ -5,6 +5,7 @@ package wasip1_test
 import (
 	"net"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/stealthrocket/net/wasip1"
@@ -20,17 +21,20 @@ func TestConn(t *testing.T) {
 			network: "tcp",
 			address: ":0",
 		},
+
 		{
 			network: "tcp4",
 			address: ":0",
 		},
+
 		{
 			network: "tcp6",
 			address: ":0",
 		},
+
 		{
 			network: "unix",
-			address: ":0",
+			address: "wasip1.sock",
 		},
 	}
 
@@ -39,7 +43,6 @@ func TestConn(t *testing.T) {
 			nettest.TestConn(t, func() (c1, c2 net.Conn, stop func(), err error) {
 				network := test.network
 				address := test.address
-
 				switch network {
 				case "unix":
 					address = filepath.Join(t.TempDir(), address)
@@ -79,6 +82,94 @@ func TestConn(t *testing.T) {
 					return nil, nil, nil, err
 				}
 			})
+		})
+	}
+}
+
+func TestPacketConn(t *testing.T) {
+	// Note: this is not as thorough of a test as TestConn because UDP is lossy
+	// and building a net.Conn on top of a net.PacketConn causes tests to fail
+	// due to packet losses.
+	tests := []struct {
+		network string
+		address string
+	}{
+		{
+			network: "udp",
+			address: "127.0.0.1:0",
+		},
+
+		{
+			network: "udp4",
+			address: "127.0.0.1:0",
+		},
+
+		{
+			network: "udp6",
+			address: "[::1]:0",
+		},
+
+		{
+			network: "unixgram",
+			address: filepath.Join(t.TempDir(), "wasip1.sock"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.network, func(t *testing.T) {
+			network := test.network
+			address := test.address
+
+			c1, err := wasip1.ListenPacket(network, address)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c1.Close()
+			addr := c1.LocalAddr()
+
+			c, err := wasip1.Dial(addr.Network(), addr.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			c2 := c.(net.PacketConn)
+			defer c2.Close()
+
+			rb2 := make([]byte, 128)
+			wb := []byte("PACKETCONN TEST")
+
+			// On unix the domain, the local address of connected sockets is
+			// empty which makes it impossible for the listening connection
+			// to send it a packet.
+			if network != "unixgram" {
+				if n, err := c1.WriteTo(wb, c2.LocalAddr()); err != nil {
+					t.Fatal(err)
+				} else if n != len(wb) {
+					t.Fatalf("write with wrong number of bytes: want=%d got=%d", len(wb), n)
+				}
+
+				if n, addr, err := c2.ReadFrom(rb2); err != nil {
+					t.Fatal(err)
+				} else if n != len(wb) {
+					t.Fatalf("read with wrong number of bytes: want=%d got=%d", len(wb), n)
+				} else if !reflect.DeepEqual(addr, c1.LocalAddr()) {
+					t.Fatalf("read from wrong address: want=%s got=%s", c1.LocalAddr(), addr)
+				}
+			}
+
+			if n, err := c.Write(wb); err != nil {
+				t.Fatal(err)
+			} else if n != len(wb) {
+				t.Fatalf("write with wrong number of bytes: want=%d got=%d", len(wb), n)
+			}
+
+			rb1 := make([]byte, 128)
+			if n, addr, err := c1.ReadFrom(rb1); err != nil {
+				t.Fatal(err)
+			} else if n != len(wb) {
+				t.Fatalf("read with wrong number of bytes: want=%d got=%d", len(wb), n)
+			} else if !reflect.DeepEqual(addr, c2.LocalAddr()) {
+				t.Fatalf("read from wrong address: want=%s got=%s", c2.LocalAddr(), addr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR adds `wasip1.ListenPacket` which is the equivalent of `net.ListenPacket`, and an implementation of `net.PacketConn` using the `sock_send_to` and `sock_recv_from` host functions of wasmedge.

The tests validate the behavior of IP and Unix Datagram sockets, and addresses a couple of bugs that I hit along the way.

This will be useful to support https://go-review.googlesource.com/c/go/+/500579/13; I also intend to add an example showcasing end-to-end DNS with `net.Resolver` and https://github.com/miekg/dns.