### PR TITLE
mysql: always import driver

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -13,3 +13,5 @@
 // When compiling to other targets than GOOS=wasip1, importing this package has
 // no effect.
 package mysql
+
+import _ "github.com/go-sql-driver/mysql"


### PR DESCRIPTION
When under `GOOS=wasip1`, the `github.com/go-sql-driver/mysql` driver is imported and automatically registered with the `database/sql` package. When not under `GOOS=wasip1`, the driver package isn't imported and so isn't registered.

This commit updates the mysql package to always import the driver and always register it with `database/sql`.